### PR TITLE
Add buffering layer

### DIFF
--- a/cmd/digitalocean_exporter/main.go
+++ b/cmd/digitalocean_exporter/main.go
@@ -4,15 +4,18 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
+	"net"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/andrewsomething/digitalocean_exporter"
 	"github.com/digitalocean/godo"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/satori/go.uuid"
 	"golang.org/x/oauth2"
 )
 
@@ -42,6 +45,58 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 	}, nil
 }
 
+type Handler struct {
+	metricsHandler    http.Handler
+	metricsPathRegexp *regexp.Regexp
+}
+
+func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if h.metricsHandler == nil {
+		logrus.Fatalln("metricsHandler is not set")
+	}
+
+	host, _, _ := net.SplitHostPort(r.RemoteAddr)
+	ID := uuid.NewV4()
+
+	logrus.WithFields(logrus.Fields{
+		"requestID":  ID,
+		"host":       host,
+		"method":     r.Method,
+		"requestURI": r.RequestURI,
+		"protocol":   r.Proto,
+		"userAgent":  r.UserAgent(),
+	}).Infoln("Started request")
+
+	startedAt := time.Now()
+	defer func() {
+		duration := time.Now().Sub(startedAt)
+		logrus.WithFields(logrus.Fields{
+			"requestID": ID,
+			"duration":  duration.String(),
+		}).Infoln("Finished request")
+	}()
+
+	if h.metricsPathRegexp.MatchString(r.RequestURI) {
+		h.metricsHandler.ServeHTTP(rw, r)
+	} else {
+		rw.WriteHeader(404)
+		rw.Write([]byte(`<html>
+		<head><title>DigitalOcean Exporter</title></head>
+		<body>
+		<h1>DigitalOcean Exporter</h1>
+		<p><a href='` + *metricsPath + `'>Metrics</a></p>
+		</body>
+		</html>`))
+	}
+}
+
+func newHandler(metricsPath string) *Handler {
+	return &Handler{
+		metricsHandler:    prometheus.Handler(),
+		metricsPathRegexp: regexp.MustCompile(fmt.Sprintf("^%s$", metricsPath)),
+	}
+}
+
 func main() {
 	flag.Parse()
 	if *versionFlag {
@@ -50,7 +105,7 @@ func main() {
 	}
 
 	if *apiToken == "" {
-		log.Fatal("A DigitalOcean API token must be specified with '-token' flag")
+		logrus.Fatalln("A DigitalOcean API token must be specified with '-token' flag")
 	}
 
 	if *debug {
@@ -68,20 +123,8 @@ func main() {
 	newExporter := digitaloceanexporter.New(digitalOceanService)
 	prometheus.MustRegister(newExporter)
 
-	http.Handle(*metricsPath, prometheus.Handler())
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`<html>
-		<head><title>DigitalOcean Exporter</title></head>
-		<body>
-		<h1>DigitalOcean Exporter</h1>
-		<p><a href='` + *metricsPath + `'>Metrics</a></p>
-		</body>
-		</html>`))
-	})
-
-	log.Printf("starting DigitalOcean exporter on %q", *listenAddr)
-
-	if err := http.ListenAndServe(*listenAddr, nil); err != nil {
-		log.Fatalf("cannot start DigitalOcean exporter: %s", err)
+	logrus.Printf("Starting DigitalOcean exporter on %q", *listenAddr)
+	if err := http.ListenAndServe(*listenAddr, newHandler(*metricsPath)); err != nil {
+		logrus.Fatalf("Cannot start DigitalOcean exporter: %s", err)
 	}
 }

--- a/digitalocean_service.go
+++ b/digitalocean_service.go
@@ -3,14 +3,19 @@ package digitaloceanexporter
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/digitalocean/godo"
 )
 
+const (
+	DefaultRefreshInterval int = 60
+)
+
 // DigitalOceanService is a wrapper around godo.Client.
 type DigitalOceanService struct {
-	C *godo.Client
+	Buffer *DigitalOceanBuffer
 }
 
 // DropletCounter is a struct holding information about a Droplet.
@@ -53,30 +58,54 @@ func newPageOpt() *godo.ListOptions {
 }
 
 // Droplets retrieves a count of Droplets grouped by status, size, and region.
-func (s *DigitalOceanService) Droplets() (map[DropletCounter]int, error) {
-	droplets, err := listDroplets(s)
-
-	counters := make(map[DropletCounter]int)
-
-	for _, d := range droplets {
-		c := DropletCounter{
-			d.Status,
-			d.Region.Slug,
-			d.Size.Slug,
-		}
-		counters[c]++
-	}
-
-	return counters, err
+func (s *DigitalOceanService) Droplets() map[DropletCounter]int {
+	return s.Buffer.Droplets
 }
 
-func listDroplets(s *DigitalOceanService) ([]godo.Droplet, error) {
+// FloatingIPs retrieves a count of Floating IPs grouped by status and region.
+func (s *DigitalOceanService) FloatingIPs() map[FlipCounter]int {
+	return s.Buffer.FloatingIPs
+}
+
+// LoadBalancers retrieves a count of Load Balancers grouped by status and region.
+func (s *DigitalOceanService) LoadBalancers() map[LoadBalancerCounter]int {
+	return s.Buffer.LoadBalancers
+}
+
+// Tags retrieves a count of Tags grouped by name and resource type.
+func (s *DigitalOceanService) Tags() map[TagCounter]int {
+	return s.Buffer.Tags
+}
+
+// Volumes retrieves a count of Volumes grouped by status, size, and region.
+func (s *DigitalOceanService) Volumes() map[VolumeCounter]int {
+	return s.Buffer.Volumes
+}
+
+func NewDigitalOceanService(buffer *DigitalOceanBuffer) *DigitalOceanService {
+	return &DigitalOceanService{
+		Buffer: buffer,
+	}
+}
+
+type DigitalOceanBuffer struct {
+	client          *godo.Client
+	refreshInterval time.Duration
+
+	Droplets      map[DropletCounter]int
+	FloatingIPs   map[FlipCounter]int
+	LoadBalancers map[LoadBalancerCounter]int
+	Tags          map[TagCounter]int
+	Volumes       map[VolumeCounter]int
+}
+
+func (b *DigitalOceanBuffer) listDroplets() ([]godo.Droplet, error) {
 	ctx := context.TODO()
 	dropletList := []godo.Droplet{}
 	pageOpt := newPageOpt()
 
 	for {
-		droplets, resp, err := s.C.Droplets.List(ctx, pageOpt)
+		droplets, resp, err := b.client.Droplets.List(ctx, pageOpt)
 		logSearchRequest("Droplets", pageOpt, len(droplets), err)
 
 		if err != nil {
@@ -102,38 +131,31 @@ func listDroplets(s *DigitalOceanService) ([]godo.Droplet, error) {
 	return dropletList, nil
 }
 
-// FloatingIPs retrieves a count of Floating IPs grouped by status and region.
-func (s *DigitalOceanService) FloatingIPs() (map[FlipCounter]int, error) {
-	fips, err := listFips(s)
+func (b *DigitalOceanBuffer) prepareDroplets() {
+	counters := make(map[DropletCounter]int)
 
-	counters := make(map[FlipCounter]int)
+	droplets, err := b.listDroplets()
+	logLastError(err)
 
-	for _, fip := range fips {
-		var status string
-
-		switch {
-		case fip.Droplet == nil:
-			status = "unassigned"
-		default:
-			status = "assigned"
-		}
-		c := FlipCounter{
-			status,
-			fip.Region.Slug,
+	for _, d := range droplets {
+		c := DropletCounter{
+			d.Status,
+			d.Region.Slug,
+			d.Size.Slug,
 		}
 		counters[c]++
 	}
 
-	return counters, err
+	b.Droplets = counters
 }
 
-func listFips(s *DigitalOceanService) ([]godo.FloatingIP, error) {
+func (b *DigitalOceanBuffer) listFips() ([]godo.FloatingIP, error) {
 	ctx := context.TODO()
 	fipList := []godo.FloatingIP{}
 	pageOpt := newPageOpt()
 
 	for {
-		fips, resp, err := s.C.FloatingIPs.List(ctx, pageOpt)
+		fips, resp, err := b.client.FloatingIPs.List(ctx, pageOpt)
 		logSearchRequest("FloatingIPs", pageOpt, len(fips), err)
 
 		if err != nil {
@@ -159,30 +181,38 @@ func listFips(s *DigitalOceanService) ([]godo.FloatingIP, error) {
 	return fipList, nil
 }
 
-// LoadBalancers retrieves a count of Load Balancers grouped by status and region.
-func (s *DigitalOceanService) LoadBalancers() (map[LoadBalancerCounter]int, error) {
-	lbs, err := listLoadBalancers(s)
+func (b *DigitalOceanBuffer) prepareFloatingIPs() {
+	counters := make(map[FlipCounter]int)
 
-	counters := make(map[LoadBalancerCounter]int)
+	floatingIPs, err := b.listFips()
+	logLastError(err)
 
-	for _, lb := range lbs {
-		c := LoadBalancerCounter{
-			lb.Status,
-			lb.Region.Slug,
+	for _, fip := range floatingIPs {
+		var status string
+
+		switch {
+		case fip.Droplet == nil:
+			status = "unassigned"
+		default:
+			status = "assigned"
+		}
+		c := FlipCounter{
+			status,
+			fip.Region.Slug,
 		}
 		counters[c]++
 	}
 
-	return counters, err
+	b.FloatingIPs = counters
 }
 
-func listLoadBalancers(s *DigitalOceanService) ([]godo.LoadBalancer, error) {
+func (b *DigitalOceanBuffer) listLoadBalancers() ([]godo.LoadBalancer, error) {
 	ctx := context.TODO()
 	lbList := []godo.LoadBalancer{}
 	pageOpt := newPageOpt()
 
 	for {
-		lbs, resp, err := s.C.LoadBalancers.List(ctx, pageOpt)
+		lbs, resp, err := b.client.LoadBalancers.List(ctx, pageOpt)
 		logSearchRequest("LoadBalancers", pageOpt, len(lbs), err)
 
 		if err != nil {
@@ -208,32 +238,30 @@ func listLoadBalancers(s *DigitalOceanService) ([]godo.LoadBalancer, error) {
 	return lbList, nil
 }
 
-// Tags retrieves a count of Tags grouped by name and resource type.
-func (s *DigitalOceanService) Tags() (map[TagCounter]int, error) {
-	tags, err := listTags(s)
+func (b *DigitalOceanBuffer) prepareLoadBalancers() {
+	counters := make(map[LoadBalancerCounter]int)
 
-	counters := make(map[TagCounter]int)
+	loadBallancers, err := b.listLoadBalancers()
+	logLastError(err)
 
-	for _, t := range tags {
-		// Note: Currently only Droplets may be tagged.
-		// reflect.ValueOf(t.Resources).Elem().Type().Field(0).Name
-		c := TagCounter{
-			t.Name,
-			"droplets",
+	for _, lb := range loadBallancers {
+		c := LoadBalancerCounter{
+			lb.Status,
+			lb.Region.Slug,
 		}
-		counters[c] = counters[c] + t.Resources.Droplets.Count
+		counters[c]++
 	}
 
-	return counters, err
+	b.LoadBalancers = counters
 }
 
-func listTags(s *DigitalOceanService) ([]godo.Tag, error) {
+func (b *DigitalOceanBuffer) listTags() ([]godo.Tag, error) {
 	ctx := context.TODO()
 	tagList := []godo.Tag{}
 	pageOpt := newPageOpt()
 
 	for {
-		tags, resp, err := s.C.Tags.List(ctx, pageOpt)
+		tags, resp, err := b.client.Tags.List(ctx, pageOpt)
 		logSearchRequest("Tags", pageOpt, len(tags), err)
 
 		if err != nil {
@@ -259,33 +287,26 @@ func listTags(s *DigitalOceanService) ([]godo.Tag, error) {
 	return tagList, nil
 }
 
-// Volumes retrieves a count of Volumes grouped by status, size, and region.
-func (s *DigitalOceanService) Volumes() (map[VolumeCounter]int, error) {
-	volumes, err := listVolumes(s)
+func (b *DigitalOceanBuffer) prepareTags() {
+	counters := make(map[TagCounter]int)
 
-	counters := make(map[VolumeCounter]int)
+	tags, err := b.listTags()
+	logLastError(err)
 
-	for _, v := range volumes {
-		var status string
-
-		switch {
-		case len(v.DropletIDs) > 0:
-			status = "attached"
-		default:
-			status = "unattached"
+	for _, t := range tags {
+		// Note: Currently only Droplets may be tagged.
+		// reflect.ValueOf(t.Resources).Elem().Type().Field(0).Name
+		c := TagCounter{
+			t.Name,
+			"droplets",
 		}
-		c := VolumeCounter{
-			status,
-			v.Region.Slug,
-			strconv.FormatInt(v.SizeGigaBytes, 10),
-		}
-		counters[c]++
+		counters[c] = counters[c] + t.Resources.Droplets.Count
 	}
 
-	return counters, err
+	b.Tags = counters
 }
 
-func listVolumes(s *DigitalOceanService) ([]godo.Volume, error) {
+func (b *DigitalOceanBuffer) listVolumes() ([]godo.Volume, error) {
 	ctx := context.TODO()
 	volumeList := []godo.Volume{}
 	volumeParams := &godo.ListVolumeParams{
@@ -293,7 +314,7 @@ func listVolumes(s *DigitalOceanService) ([]godo.Volume, error) {
 	}
 
 	for {
-		volumes, resp, err := s.C.Storage.ListVolumes(ctx, volumeParams)
+		volumes, resp, err := b.client.Storage.ListVolumes(ctx, volumeParams)
 		logSearchRequest("Volumes", volumeParams.ListOptions, len(volumes), err)
 
 		if err != nil {
@@ -319,6 +340,72 @@ func listVolumes(s *DigitalOceanService) ([]godo.Volume, error) {
 	return volumeList, nil
 }
 
+func (b *DigitalOceanBuffer) prepareVolumes() {
+	counters := make(map[VolumeCounter]int)
+
+	volumes, err := b.listVolumes()
+	logLastError(err)
+
+	for _, v := range volumes {
+		var status string
+
+		switch {
+		case len(v.DropletIDs) > 0:
+			status = "attached"
+		default:
+			status = "unattached"
+		}
+		c := VolumeCounter{
+			status,
+			v.Region.Slug,
+			strconv.FormatInt(v.SizeGigaBytes, 10),
+		}
+		counters[c]++
+	}
+
+	b.Volumes = counters
+}
+
+func (n *DigitalOceanBuffer) refresh() {
+	logrus.Infoln("Refreshing DigitalOcean data")
+	startedAt := time.Now()
+
+	n.prepareDroplets()
+	n.prepareFloatingIPs()
+	n.prepareLoadBalancers()
+	n.prepareTags()
+	n.prepareVolumes()
+
+	defer func() {
+		duration := time.Now().Sub(startedAt)
+		logrus.WithFields(logrus.Fields{
+			"duration": duration.String(),
+		}).Infoln("Finished DigitalOcean data refresh")
+	}()
+}
+
+func (n *DigitalOceanBuffer) watch() {
+	n.refresh()
+	for {
+		select {
+		case <-time.After(n.refreshInterval):
+			n.refresh()
+		}
+	}
+}
+
+func NewDigitalOceanBuffer(client *godo.Client, refreshInterval int) *DigitalOceanBuffer {
+	interval := time.Duration(refreshInterval) * time.Second
+	buffer := &DigitalOceanBuffer{
+		client:          client,
+		refreshInterval: interval,
+	}
+
+	go buffer.watch()
+
+	return buffer
+}
+
 func logSearchRequest(resource string, pageOpt *godo.ListOptions, elementsCount int, err error) {
 	logrus.Debugf(
 		"Looking for %s: page=%d perPage=%d found=%d error=%v",
@@ -328,4 +415,10 @@ func logSearchRequest(resource string, pageOpt *godo.ListOptions, elementsCount 
 		elementsCount,
 		err,
 	)
+}
+
+func logLastError(err error) {
+	if err != nil {
+		logrus.WithError(err).Errorln("Error while requesting DigitalOcean")
+	}
 }

--- a/digitalocean_service_test.go
+++ b/digitalocean_service_test.go
@@ -39,12 +39,10 @@ func TestDroplets(t *testing.T) {
 
 	for _, tt := range dropletTests {
 		apiServer(t, "/v2/droplets", tt.resp, func() {
-			dos := getDosClient()
-			dropletCounters, err := dos.Droplets()
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-			assert.Equal(t, tt.expected, dropletCounters, "they should be equal")
+			dob := getDOBuffer()
+			dob.prepareDroplets()
+			dos := NewDigitalOceanService(dob)
+			assert.Equal(t, tt.expected, dos.Droplets(), "they should be equal")
 		})
 	}
 }
@@ -76,12 +74,10 @@ func TestFloatingIPs(t *testing.T) {
 
 	for _, tt := range fipTests {
 		apiServer(t, "/v2/floating_ips", tt.resp, func() {
-			dos := getDosClient()
-			fipCounters, err := dos.FloatingIPs()
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-			assert.Equal(t, tt.expected, fipCounters, "they should be equal")
+			dob := getDOBuffer()
+			dob.prepareFloatingIPs()
+			dos := NewDigitalOceanService(dob)
+			assert.Equal(t, tt.expected, dos.FloatingIPs(), "they should be equal")
 		})
 	}
 }
@@ -113,12 +109,10 @@ func TestLoadBalancers(t *testing.T) {
 
 	for _, tt := range lbTests {
 		apiServer(t, "/v2/load_balancers", tt.resp, func() {
-			dos := getDosClient()
-			fipCounters, err := dos.LoadBalancers()
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-			assert.Equal(t, tt.expected, fipCounters, "they should be equal")
+			dob := getDOBuffer()
+			dob.prepareLoadBalancers()
+			dos := NewDigitalOceanService(dob)
+			assert.Equal(t, tt.expected, dos.LoadBalancers(), "they should be equal")
 		})
 	}
 }
@@ -140,12 +134,10 @@ func TestTags(t *testing.T) {
 
 	for _, tt := range tagTests {
 		apiServer(t, "/v2/tags", tt.resp, func() {
-			dos := getDosClient()
-			tagCounters, err := dos.Tags()
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-			assert.Equal(t, tt.expected, tagCounters, "they should be equal")
+			dob := getDOBuffer()
+			dob.prepareTags()
+			dos := NewDigitalOceanService(dob)
+			assert.Equal(t, tt.expected, dos.Tags(), "they should be equal")
 		})
 	}
 }
@@ -177,12 +169,10 @@ func TestVolumes(t *testing.T) {
 
 	for _, tt := range volumeTests {
 		apiServer(t, "/v2/volumes", tt.resp, func() {
-			dos := getDosClient()
-			volumeCounters, err := dos.Volumes()
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-			assert.Equal(t, tt.expected, volumeCounters, "they should be equal")
+			dob := getDOBuffer()
+			dob.prepareVolumes()
+			dos := NewDigitalOceanService(dob)
+			assert.Equal(t, tt.expected, dos.Volumes(), "they should be equal")
 		})
 	}
 }
@@ -199,15 +189,17 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 	}, nil
 }
 
-func getDosClient() *DigitalOceanService {
+func getDOBuffer() *DigitalOceanBuffer {
 	ts := &TokenSource{AccessToken: "fake-testing-token"}
 	oauthClient := oauth2.NewClient(oauth2.NoContext, ts)
 	c := godo.NewClient(oauthClient)
 	c.BaseURL = GodoBase
 
-	dos := &DigitalOceanService{c}
+	dob := &DigitalOceanBuffer{
+		client: c,
+	}
 
-	return dos
+	return dob
 }
 
 func apiServer(t testing.TB, path string, resp string, test func()) {


### PR DESCRIPTION
This PR adds a `buffer` layer that breaks connection between request from Prometheus server to the exporter and request from exporter to DigitalOcean API.

Why it was added? Because long running exporter when is requested by several Prometheus servers (which is nothing unusual - it's a situation when one have several Prometheus servers that are working as HA cluster) has big performance problems. Request from Prometheus is queued and locked before previous request was finished. It could be request from other server but in case of long DO responses it could be even a previous request from the same server! This also requires user to set a quite big timeout on Prometheus side to increase a possibility that request will be finished successfully (which is also not a good idea).

The second problem is that DO is requested each time. In a situation described above - several Prometheus servers - this is not OK because:
- server A may have different data than server B even if both servers requested exporter at the same time,
- API rate limit can be achieved very quick, especially when there is many resources on DO side.

This PR tries to resolve above problems. It adds a goroutine that periodically requests DO and gets data about usage. The time between subsequent requests to DO can be set from command line with `-refresh-interval` option. The `DigitalOceanService` struct was changed to be a simple proxy that gets buffered data from `DigitalOceanBuffer` and change them into metric. If several Prometheus servers will request exporter then each request will re-use current data from the buffer. This ends - using times from environment where I'm using this exporter - with Prometheus requests finished in ~10ms instead of 25s! While the requests made from `DigitalOceanBuffer` to DO take ~15-20s instead of ~25s (probably because of a lower concurrency).