### PR TITLE
Make possible to set token with environment variable

### DIFF
--- a/cmd/digitalocean_exporter/main.go
+++ b/cmd/digitalocean_exporter/main.go
@@ -49,7 +49,11 @@ func main() {
 	}
 
 	if *apiToken == "" {
-		log.Fatal("A DigitalOcean API token must be specified with '-token' flag")
+		token := os.Getenv("DIGITALOCEAN_TOKEN")
+		if token == "" {
+			log.Fatal("A DigitalOcean API token must be specified with '-token' flag or with DIGITALOCEAN_TOKEN environment variable")
+		}
+		*apiToken = token
 	}
 
 	if *debug {


### PR DESCRIPTION
Currently the token may be specified only with command line flag. This leaks the value of token as described at https://gitlab.com/gitlab-com/infrastructure/issues/2375. To know what is the token one need only to execute `ps aux | grep digitalocean_exporter`.

With this change the token may be set with environment variable so it will be not visible in system processes list.