### PR TITLE
Mark droplets metric with tags label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /go/src/github.com/andrewsomething/digitalocean_exporter
 RUN apk add -U ca-certificates
 
 COPY . .
-RUN apk add --no-cache git; \
-    go get -v ./cmd/digitalocean_exporter; \
-    which digitalocean_exporter; \
+RUN apk add --no-cache git && \
+    go get -v ./cmd/digitalocean_exporter && \
+    which digitalocean_exporter && \
     apk del git
 
 ENTRYPOINT ["/go/bin/digitalocean_exporter", "-listen", "0.0.0.0:9292"]

--- a/cmd/digitalocean_exporter/main.go
+++ b/cmd/digitalocean_exporter/main.go
@@ -56,7 +56,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	ID := uuid.NewV4()
+	ID, _ := uuid.NewV4()
 
 	logrus.WithFields(logrus.Fields{
 		"requestID":  ID,

--- a/digitalocean_collector.go
+++ b/digitalocean_collector.go
@@ -37,7 +37,7 @@ func NewDigitalOceanCollector(dos DigitalOceanSource) *DigitalOceanCollector {
 		Droplets: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "droplets", "count"),
 			"Number of Droplets by region, size, and status.",
-			[]string{"region", "size", "status"},
+			[]string{"region", "size", "status", "tags"},
 			nil,
 		),
 		FloatingIPs: prometheus.NewDesc(
@@ -88,6 +88,7 @@ func (c *DigitalOceanCollector) collectDropletCounts(ch chan<- prometheus.Metric
 			d.region,
 			d.size,
 			d.status,
+			d.tags,
 		)
 	}
 }

--- a/digitalocean_service.go
+++ b/digitalocean_service.go
@@ -373,7 +373,7 @@ func (b *DigitalOceanBuffer) prepareVolumes() {
 }
 
 func (b *DigitalOceanBuffer) refresh() {
-	b.refreshID = uuid.NewV4()
+	b.refreshID, _ = uuid.NewV4()
 	log := logrus.WithField("refreshID", b.refreshID)
 
 	log.Infoln("Starting DigitalOcean data refresh")

--- a/digitalocean_service.go
+++ b/digitalocean_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -25,6 +26,7 @@ type DropletCounter struct {
 	status string
 	region string
 	size   string
+	tags   string
 }
 
 // FlipCounter is a struct holding information about a Floating IP.
@@ -145,6 +147,7 @@ func (b *DigitalOceanBuffer) prepareDroplets() {
 			d.Status,
 			d.Region.Slug,
 			d.Size.Slug,
+			strings.Join(d.Tags, ","),
 		}
 		counters[c]++
 	}


### PR DESCRIPTION
This PR adds a `tags` label to `digitalocean_droplets_count` metric. This allows to group tagged droplets in metric aggregations.