### PR TITLE
Provide a query_duration_seconds metric.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ digitalocean_floating_ips_count{region="nyc3",status="unassigned"} 1
 # HELP digitalocean_load_balancers_count Number of Load Balancers by region and status.
 # TYPE digitalocean_load_balancers_count gauge
 digitalocean_load_balancers_count{region="nyc3",status="active"} 1
+# HELP digitalocean_query_duration_seconds Time elapsed while querying the DigitalOcean API in seconds.
+# TYPE digitalocean_query_duration_seconds gauge
+digitalocean_query_duration_seconds 4.806081399
 # HELP digitalocean_tags_count Count of tagged resources by name and resource type.
 # TYPE digitalocean_tags_count gauge
 digitalocean_tags_count{name="frontend",resource_type="droplets"} 0

--- a/digitalocean_service.go
+++ b/digitalocean_service.go
@@ -86,6 +86,11 @@ func (s *DigitalOceanService) Volumes() map[VolumeCounter]int {
 	return s.Buffer.Volumes
 }
 
+// QueryDuration reports the time elapsed while querying the DigitalOcean API.
+func (s *DigitalOceanService) QueryDuration() time.Duration {
+	return s.Buffer.QueryDuration
+}
+
 func NewDigitalOceanService(buffer *DigitalOceanBuffer) *DigitalOceanService {
 	return &DigitalOceanService{
 		Buffer: buffer,
@@ -102,6 +107,8 @@ type DigitalOceanBuffer struct {
 	LoadBalancers map[LoadBalancerCounter]int
 	Tags          map[TagCounter]int
 	Volumes       map[VolumeCounter]int
+
+	QueryDuration time.Duration
 }
 
 func (b *DigitalOceanBuffer) listDroplets() ([]godo.Droplet, error) {
@@ -387,6 +394,7 @@ func (b *DigitalOceanBuffer) refresh() {
 
 	defer func() {
 		duration := time.Now().Sub(startedAt)
+		b.QueryDuration = duration
 		log.WithField("duration", duration.String()).Infoln("Finished DigitalOcean data refresh")
 	}()
 }


### PR DESCRIPTION
Provides an internal metric tracking the time elapsed while querying the DigitalOcean API. Closes: #14 